### PR TITLE
Invert TES relay bits

### DIFF
--- a/firmware/src/TES_relay_set.c
+++ b/firmware/src/TES_relay_set.c
@@ -20,9 +20,11 @@
 void TES_relay_set(uint32_t x)
 {
     unsigned int n;
+    unsigned int bit;
+
     for (n = 0; n < NUM_TES_CHANNELS; n++)
     {
-        if (x & (0x1 << n))
+        if (x & (0x1 << tes_value_bit[n]))
         {
             PLIB_PORTS_PinSet(PORTS_ID_0, tes_set_port[n], tes_set_bit[n]);
         }

--- a/firmware/src/ccard.c
+++ b/firmware/src/ccard.c
@@ -63,10 +63,11 @@ SUBSTITUTE GOODS, TECHNOLOGY, SERVICES, OR ANY CLAIMS BY THIRD PARTIES
 
 // *****************************************************************************
 // Taken from ccard.h
-uint32_t tes_reset_port[NUM_TES_CHANNELS] = { 4,  4,  6,  4,  0,  5,  3,  3,  3,  3,  3,  3, 4  };
-uint32_t tes_reset_bit[NUM_TES_CHANNELS]  = { 4,  2,  12, 1,  7,  1,  7,  5,  13, 10, 3,  8, 5  };
-uint32_t tes_set_port[NUM_TES_CHANNELS]   = { 4,  6,  6,  4,  0,  5,  3,  3,  3,  3,  3,  3, 6  };
-uint32_t tes_set_bit[NUM_TES_CHANNELS]    = { 3,  13, 14, 0,  6,  0,  6,  4,  12, 11, 2,  9, 15 };
+uint32_t tes_reset_port[NUM_TES_CHANNELS] = { 4,  4,  6,  4,  0,  5,  3,  3,   3,  3,  3,  3, 4  };
+uint32_t tes_reset_bit[NUM_TES_CHANNELS]  = { 4,  2,  12, 1,  7,  1,  7,  5,  13, 10,  3,  8, 5  };
+uint32_t tes_set_port[NUM_TES_CHANNELS]   = { 4,  6,  6,  4,  0,  5,  3,  3,   3,  3,  3,  3, 6  };
+uint32_t tes_set_bit[NUM_TES_CHANNELS]    = { 3,  13, 14, 0,  6,  0,  6,  4,  12, 11,  2,  9, 15 };
+uint32_t tes_value_bit[NUM_TES_CHANNELS]  = { 0,  1,  2,  3,  4,  5,  6,  7,   8,  9, 10, 11, 16 };
 
 // Relays default state
 uint32_t RELAY_DEFAULT = 0x00;

--- a/firmware/src/ccard.c
+++ b/firmware/src/ccard.c
@@ -63,10 +63,10 @@ SUBSTITUTE GOODS, TECHNOLOGY, SERVICES, OR ANY CLAIMS BY THIRD PARTIES
 
 // *****************************************************************************
 // Taken from ccard.h
-uint32_t tes_reset_port[NUM_TES_CHANNELS] = { 4,  6,  6,  4,  0,  5,  3,  3,  3,  3,  3,  3, 4  };
-uint32_t tes_reset_bit[NUM_TES_CHANNELS]  = { 3,  13, 14, 0,  6,  0,  6,  4,  12, 11, 2,  9, 5  };
-uint32_t tes_set_port[NUM_TES_CHANNELS]   = { 4,  4,  6,  4,  0,  5,  3,  3,  3,  3,  3,  3, 6  };
-uint32_t tes_set_bit[NUM_TES_CHANNELS]    = { 4,  2,  12, 1,  7,  1,  7,  5,  13, 10, 3,  8, 15 };
+uint32_t tes_reset_port[NUM_TES_CHANNELS] = { 4,  4,  6,  4,  0,  5,  3,  3,  3,  3,  3,  3, 4  };
+uint32_t tes_reset_bit[NUM_TES_CHANNELS]  = { 4,  2,  12, 1,  7,  1,  7,  5,  13, 10, 3,  8, 5  };
+uint32_t tes_set_port[NUM_TES_CHANNELS]   = { 4,  6,  6,  4,  0,  5,  3,  3,  3,  3,  3,  3, 6  };
+uint32_t tes_set_bit[NUM_TES_CHANNELS]    = { 3,  13, 14, 0,  6,  0,  6,  4,  12, 11, 2,  9, 15 };
 
 // Relays default state
 uint32_t RELAY_DEFAULT = 0x00;
@@ -305,7 +305,7 @@ void CCARD_Tasks ( void )
                 TES_relay_clear(); // clears relay drive
             }
             relay_busy = false;  // relay done
-            relay = relay & ((1 << (data_bits-1))-1);  // clear relay busy bit
+            //relay = relay & ((1 << (data_bits-1))-1);  // clear relay busy bit
             ccardData.state = CCARD_STATE_SERVICE_TASKS;
             break;
         }

--- a/firmware/src/ccard.h
+++ b/firmware/src/ccard.h
@@ -74,7 +74,7 @@ extern "C" {
 // *****************************************************************************
 // Firmware version. Coded as 6 digits in HEX, 4 bits per digit.
 // For example: Version R2.3.1 will be 0x020301
-#define FIRMWARE_VERSION 0x040004   // R4.0.1
+#define FIRMWARE_VERSION 0x040005   // R4.0.1
 
 // Number of TES relays, plus Flux ramp AC/DC Switch
 #define NUM_TES_CHANNELS 13

--- a/firmware/src/ccard.h
+++ b/firmware/src/ccard.h
@@ -74,7 +74,7 @@ extern "C" {
 // *****************************************************************************
 // Firmware version. Coded as 6 digits in HEX, 4 bits per digit.
 // For example: Version R2.3.1 will be 0x020301
-#define FIRMWARE_VERSION 0x040005   // R4.0.1
+#define FIRMWARE_VERSION 0x040006   // R4.0.1
 
 // Number of TES relays, plus Flux ramp AC/DC Switch
 #define NUM_TES_CHANNELS 13

--- a/firmware/src/ccard.h
+++ b/firmware/src/ccard.h
@@ -115,6 +115,7 @@ extern uint32_t tes_reset_port[NUM_TES_CHANNELS];
 extern uint32_t tes_reset_bit[NUM_TES_CHANNELS];
 extern uint32_t tes_set_port[NUM_TES_CHANNELS];
 extern uint32_t tes_set_bit[NUM_TES_CHANNELS];
+extern uint32_t tes_value_bit[NUM_TES_CHANNELS];
 extern bool RELAY_LATCHING;
 
 // *****************************************************************************


### PR DESCRIPTION
Invert the 12 relays associated with the TES bias lines. This is required to match the as built wiring of the C04 board. 