### PR TITLE
Update 50K2 docs

### DIFF
--- a/README.SpiRegisterMap.md
+++ b/README.SpiRegisterMap.md
@@ -25,15 +25,13 @@ For a read command, the `data` field is ignored. To get the content of the regis
 | 0x00    | Read-only  | Firmware version, coded in HEX in three bytes, one byte per version digit.<br>For example: Version `R2.3.1` is coded as `0x020301`.
 | 0x01    | Read-only  | Status register. Not implemented, it always returns 0.
 | 0x02    | Read/Write | TES bias relay control. 12 bits, one bit per each relay., plus the main AC/DC relay in bit 12
-| 0x03    | Read-only  | HEMT bias value.
+| 0x03    | Read-only  | HEMT bias value. 
 | 0x04    | Read-only  | 50K bias value.
 | 0x05    | Read-only  | Temperature value.
 | 0x06    | Read-only  | Cycle counts. Return the number of SPI read operations.
-| 0x07    | Read/Write | Power supply enables, 4 bits:<ul><li>bit 0 : HEMT</li><li>bit 1 : 50K</li>
-<li>bit 2 : HEMT2</li><li>bit 3 : 50K2</li>
-</ul>
+| 0x07    | Read/Write | Power supply enables, 4 bits:<ul><li>bit 0 : HEMT</li><li>bit 1 : 50K</li><li>bit 2 : HEMT2</li><li>bit 3 : 50K2</li></ul>
 | 0x08    | Read/Write | Flux ramp controls, not used!
 | 0x09    | Read-only  | ID voltage value.
 | 0x0A    | Read-only  | HEMT2 bias value.
-| 0x0B    | Read-only  | 50K2 bias value.
+| 0x0B    | Read-only  | 50K2 bias value. Reads the 50K_I voltage into the PIC. Can be converted into Milliamps.
 | 0x0C    | Read-only  | ID2 voltage value.


### PR DESCRIPTION
I believe the steps are,

1. 50K_I signal goes into the PIC
2. Read its voltage at address 0x0B, https://github.com/slaclab/smurfc/blob/C04/firmware/src/ccard.h#L108
3. Pysmurf reads the PIC value in bits, like https://github.com/slaclab/pysmurf/blob/b5b8c054da2ee365128a25571cea64475c1f1b09/python/pysmurf/client/command/cryo_card.py#L89
4. Pysmurf converts the value from bits, to volts, to milliamps.

This is not obvious so the docs should be updated to be more informative.